### PR TITLE
Fix mobile header display

### DIFF
--- a/components/header.tsx
+++ b/components/header.tsx
@@ -16,7 +16,7 @@ type HeaderProps = {
 export default function Header({ total }: HeaderProps) {
   return (
     <Section className="flex justify-between flex-col md:flex-row">
-      <h1 className="font-mono text-xs whitespace-pre md:text-sm font-bold">
+      <h1 className="font-mono text-[0.4rem] whitespace-pre sm:text-xs md:text-sm font-bold">
         {ASCII_ART.join("\n")}
       </h1>
 


### PR DESCRIPTION
## Summary
- shrink ASCII header on small screens to prevent overflow

## Testing
- `pnpm lint` *(fails: request to npm registry blocked)*

------
https://chatgpt.com/codex/tasks/task_e_687e68b82050832c8b0fb9f84a35a432