### PR TITLE
Add selectable Catppuccin themes

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,8 +1,26 @@
 @import "tailwindcss";
 
 :root {
-  /* --background: #1D2121; */
-  /* --foreground: #E5D8AF; */
+  --background: #1e2031;
+  --foreground: #8aadf5;
+}
+
+html[data-theme="latte"] {
+  --background: #eff1f5;
+  --foreground: #4c4f69;
+}
+
+html[data-theme="frappe"] {
+  --background: #303446;
+  --foreground: #c6d0f5;
+}
+
+html[data-theme="macchiato"] {
+  --background: #24273a;
+  --foreground: #cad3f5;
+}
+
+html[data-theme="mocha"] {
   --background: #1e2031;
   --foreground: #8aadf5;
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import "./globals.css";
 import { geistMono, geistSans } from "@/lib/fonts";
+import ThemeProvider from "@/components/theme-provider";
 
 export const metadata: Metadata = {
   title: "Store.nvim - Neovim Plugin Directory",
@@ -18,6 +19,7 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
+        <ThemeProvider />
         {children}
       </body>
     </html>

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -1,4 +1,5 @@
 import Section from "./section";
+import ThemeSelector from "./theme-selector";
 
 const ASCII_ART = [
   "      _                              _",
@@ -20,7 +21,8 @@ export default function Header({ total }: HeaderProps) {
         {ASCII_ART.join("\n")}
       </h1>
 
-      <div className="flex flex-col font-mono mt-3 md:mt-0 items-end">
+      <div className="flex flex-col font-mono mt-3 md:mt-0 items-end gap-1">
+        <ThemeSelector />
         <span>Filter: {"None"}</span>
         <span>Showing 100 of {total} plugins</span>
         <span>Press ? for help</span>

--- a/components/theme-provider.tsx
+++ b/components/theme-provider.tsx
@@ -1,0 +1,13 @@
+"use client";
+import { useEffect } from "react";
+import { useStore } from "@/lib/store";
+
+export default function ThemeProvider() {
+  const theme = useStore((state) => state.theme);
+
+  useEffect(() => {
+    document.documentElement.dataset.theme = theme;
+  }, [theme]);
+
+  return null;
+}

--- a/components/theme-selector.tsx
+++ b/components/theme-selector.tsx
@@ -1,0 +1,22 @@
+"use client";
+import { useStore } from "@/lib/store";
+
+const themes = ["latte", "frappe", "macchiato", "mocha"] as const;
+
+export default function ThemeSelector() {
+  const { theme, setTheme } = useStore();
+
+  return (
+    <select
+      className="bg-background text-foreground border border-foreground rounded px-1"
+      value={theme}
+      onChange={(e) => setTheme(e.target.value as typeof themes[number])}
+    >
+      {themes.map((th) => (
+        <option key={th} value={th}>
+          {th}
+        </option>
+      ))}
+    </select>
+  );
+}

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -1,4 +1,5 @@
 import { create } from "zustand";
+import { persist } from "zustand/middleware";
 
 export type Theme = "latte" | "frappe" | "macchiato" | "mocha";
 
@@ -20,9 +21,17 @@ const initialState: State = {
   theme: "mocha",
 };
 
-export const useStore = create<State & Actions>()((set) => ({
-  ...initialState,
-  setFilter: (filter: string) => set({ filter }),
-  toggleFilter: () => set((state) => ({ showFilter: !state.showFilter })),
-  setTheme: (theme: Theme) => set({ theme }),
-}));
+export const useStore = create<State & Actions>()(
+  persist(
+    (set) => ({
+      ...initialState,
+      setFilter: (filter: string) => set({ filter }),
+      toggleFilter: () => set((state) => ({ showFilter: !state.showFilter })),
+      setTheme: (theme: Theme) => set({ theme }),
+    }),
+    {
+      name: "store-theme",
+      partialize: (state) => ({ theme: state.theme }),
+    }
+  )
+);

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -1,22 +1,28 @@
 import { create } from "zustand";
 
+export type Theme = "latte" | "frappe" | "macchiato" | "mocha";
+
 interface State {
   filter: string;
   showFilter: boolean;
+  theme: Theme;
 }
 
 interface Actions {
   setFilter: (filter: string) => void;
   toggleFilter: () => void;
+  setTheme: (theme: Theme) => void;
 }
 
 const initialState: State = {
   filter: "",
   showFilter: false,
+  theme: "mocha",
 };
 
 export const useStore = create<State & Actions>()((set) => ({
   ...initialState,
   setFilter: (filter: string) => set({ filter }),
   toggleFilter: () => set((state) => ({ showFilter: !state.showFilter })),
+  setTheme: (theme: Theme) => set({ theme }),
 }));


### PR DESCRIPTION
## Summary
- add state management for themes
- add ThemeProvider to apply selected theme
- create ThemeSelector dropdown
- integrate ThemeSelector in the header
- define Catppuccin theme colors in global CSS

## Testing
- `pnpm lint` *(fails: fetch to registry.npmjs.org blocked)*
- `pnpm prettier` *(fails: fetch to registry.npmjs.org blocked)*

------
https://chatgpt.com/codex/tasks/task_e_687e6ae6f198832c964cbdaee6f0eccf