### PR TITLE
Add install instructions modal

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,6 @@
 import Header from "@/components/header";
 import Help from "@/components/help";
+import InstallModal from "@/components/install-modal";
 import RepositoryWrapper from "@/components/repository-wrapper";
 import { retrievePlugins } from "@/lib/api";
 
@@ -12,6 +13,7 @@ export default async function Home() {
       <RepositoryWrapper repositories={repositories} />
 
       <Help />
+      <InstallModal />
     </div>
   );
 }

--- a/components/help.tsx
+++ b/components/help.tsx
@@ -28,6 +28,13 @@ export default function Help() {
     },
   };
 
+  const tableShortcuts = {
+    ...shortcuts,
+    I: {
+      description: "Show install guide",
+    },
+  };
+
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.target instanceof HTMLInputElement) return;
@@ -61,10 +68,10 @@ export default function Help() {
             </tr>
           </thead>
           <tbody className="pt-1">
-            {Object.entries(shortcuts).map(([key, { description }]) => (
+            {Object.entries(tableShortcuts).map(([key, item]) => (
               <tr key={key}>
                 <td>{key}</td>
-                <td className="text-right">{description}</td>
+                <td className="text-right">{item.description}</td>
               </tr>
             ))}
           </tbody>

--- a/components/install-modal.tsx
+++ b/components/install-modal.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Section from "./section";
+
+export default function InstallModal() {
+  const [isOpen, setIsOpen] = useState(false);
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.target instanceof HTMLInputElement) return;
+
+      if (event.key === "I") {
+        event.preventDefault();
+        setIsOpen(true);
+      } else if (event.key === "Escape") {
+        setIsOpen(false);
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, []);
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="absolute inset-0 h-full w-full bg-black/60 backdrop-blur-xs flex justify-center items-center">
+      <Section className="max-w-10/12 min-w-[200px] font-mono">
+        <h3 className="text-lg font-bold mb-2">Install store.nvim</h3>
+        <pre className="text-sm whitespace-pre-wrap">
+{`-- Using lazy.nvim
+{
+  'alex-popov-tech/store.nvim',
+  dependencies = {
+    'MunifTanjim/nui.nvim',
+    'nvim-lua/plenary.nvim',
+  },
+  config = function()
+    require('store').setup()
+  end,
+}
+`}
+        </pre>
+        <p className="text-sm mt-2">
+          Then run <code>:Store</code> inside Neovim.
+        </p>
+      </Section>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add `InstallModal` with install instructions opened by pressing `I`
- list `I` in the help overlay
- include `InstallModal` on the home page

## Testing
- `pnpm lint` *(fails: unable to fetch pnpm)*

------
https://chatgpt.com/codex/tasks/task_e_687e69b14730832cb2a265435ceee4fc