### PR TITLE
Add sorting options for repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,11 @@ topic:lsp python
 
 The above will show repositories tagged with `lsp` whose names include
 `python`.
+
+## Sorting repositories
+
+Use the sort dropdown above the list to reorder results. The available options
+are:
+
+- **Most stars** – sort repositories by star count in descending order.
+- **Recently updated** – sort repositories by their latest update date.

--- a/components/repo-list.tsx
+++ b/components/repo-list.tsx
@@ -2,7 +2,9 @@ import { Repository } from "@/lib/definitions";
 import Section from "./section";
 import RepoItem from "./repo-item";
 import RepoFilter from "./repo-filter";
+import RepoSort from "./repo-sort";
 import { useStore } from "@/lib/store";
+import { sortRepositories } from "@/lib/sort";
 import { filterRepositories } from "@/lib/filters";
 
 type RepoListProps = {
@@ -16,15 +18,17 @@ export default function RepoList({
   selected,
   setSelected,
 }: RepoListProps) {
-  const { filter } = useStore();
+  const { filter, sort } = useStore();
 
   const filtered = filterRepositories(repositories, filter);
+  const sorted = sortRepositories(filtered, sort);
 
   return (
     <Section className="h-full overflow-y-auto">
       <RepoFilter />
+      <RepoSort />
       <ul>
-        {filtered.slice(0, 100).map((repository, index) => (
+        {sorted.slice(0, 100).map((repository, index) => (
           <li key={index}>
             <RepoItem
               item={repository}

--- a/components/repo-sort.tsx
+++ b/components/repo-sort.tsx
@@ -1,0 +1,27 @@
+import { useStore, SortOption } from "@/lib/store";
+import Section from "./section";
+
+export default function RepoSort() {
+  const { sort, setSort } = useStore();
+
+  const handleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    setSort(e.target.value as SortOption);
+  };
+
+  return (
+    <Section className="relative w-full mb-3">
+      <label className="absolute -top-1/2 translate-y-1/2 left-2 bg-background px-2">
+        Sort repositories
+      </label>
+      <select
+        value={sort}
+        onChange={handleChange}
+        className="w-full focus:outline-none"
+      >
+        <option value="default">Default</option>
+        <option value="stars">Most stars</option>
+        <option value="updated">Recently updated</option>
+      </select>
+    </Section>
+  );
+}

--- a/lib/sort.ts
+++ b/lib/sort.ts
@@ -1,0 +1,15 @@
+import { Repository } from "./definitions";
+import { SortOption } from "./store";
+
+export const sortRepositories = (
+  repos: Repository[],
+  sort: SortOption,
+): Repository[] => {
+  const sorted = [...repos];
+  if (sort === "stars") {
+    sorted.sort((a, b) => b.stargazers_count - a.stargazers_count);
+  } else if (sort === "updated") {
+    sorted.sort((a, b) => Date.parse(b.updated_at) - Date.parse(a.updated_at));
+  }
+  return sorted;
+};

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -3,22 +3,27 @@ import { persist } from "zustand/middleware";
 
 export type Theme = "latte" | "frappe" | "macchiato" | "mocha";
 
+export type SortOption = "default" | "stars" | "updated";
+
 interface State {
   filter: string;
   showFilter: boolean;
   theme: Theme;
+  sort: SortOption;
 }
 
 interface Actions {
   setFilter: (filter: string) => void;
   toggleFilter: () => void;
   setTheme: (theme: Theme) => void;
+  setSort: (sort: SortOption) => void;
 }
 
 const initialState: State = {
   filter: "",
   showFilter: false,
   theme: "mocha",
+  sort: "default",
 };
 
 export const useStore = create<State & Actions>()(
@@ -28,10 +33,11 @@ export const useStore = create<State & Actions>()(
       setFilter: (filter: string) => set({ filter }),
       toggleFilter: () => set((state) => ({ showFilter: !state.showFilter })),
       setTheme: (theme: Theme) => set({ theme }),
+      setSort: (sort: SortOption) => set({ sort }),
     }),
     {
       name: "store-theme",
-      partialize: (state) => ({ theme: state.theme }),
+      partialize: (state) => ({ theme: state.theme, sort: state.sort }),
     },
   ),
 );

--- a/tests/sort.test.ts
+++ b/tests/sort.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { sortRepositories } from "../lib/sort";
+import { SortOption } from "../lib/store";
+import { Repository } from "../lib/definitions";
+
+const repos: Repository[] = [
+  {
+    full_name: "foo/bar",
+    description: "",
+    homepage: "",
+    html_url: "",
+    stargazers_count: 5,
+    watchers_count: 0,
+    fork_count: 0,
+    updated_at: "2025-07-18T00:00:00Z",
+    topics: [],
+  },
+  {
+    full_name: "baz/qux",
+    description: "",
+    homepage: "",
+    html_url: "",
+    stargazers_count: 10,
+    watchers_count: 0,
+    fork_count: 0,
+    updated_at: "2025-07-17T00:00:00Z",
+    topics: [],
+  },
+];
+
+describe("sortRepositories", () => {
+  it("sorts by stars", () => {
+    const sorted = sortRepositories(repos, "stars" as SortOption);
+    expect(sorted[0].stargazers_count).toBe(10);
+  });
+
+  it("sorts by updated date", () => {
+    const sorted = sortRepositories(repos, "updated" as SortOption);
+    expect(sorted[0].updated_at).toBe("2025-07-18T00:00:00Z");
+  });
+});


### PR DESCRIPTION
## Summary
- allow sorting repositories by stars or updated date
- display sorting dropdown
- test new sorting helper
- document sorting options in README

## Testing
- `pnpm lint`
- `pnpm tests`


------
https://chatgpt.com/codex/tasks/task_e_687ff4dc622c832cac9d0cf8d8949104