### PR TITLE
Add code highlighting for plugin READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ You can use the same UI and all of the plugin information inside Neovim with the
 
 To run the development server:
 
-```bash
+```shell
 pnpm dev
 ```
 
@@ -22,7 +22,7 @@ Use the search box (press `f` to toggle) to filter the list. You can search by
 repository name or by topic using the `topic:<name>` syntax. Combining filters
 works as expected, for example:
 
-```bash
+```shell
 topic:lsp python
 ```
 

--- a/components/repo-description.tsx
+++ b/components/repo-description.tsx
@@ -1,6 +1,9 @@
+import { useEffect, useRef } from "react";
 import { Repository } from "@/lib/definitions";
 import Section from "./section";
 import { useRetrieveReadme } from "@/lib/api";
+import hljs from "highlight.js";
+import "highlight.js/styles/github-dark.css";
 
 type RepoDescriptionProps = {
   repo: Repository;
@@ -8,6 +11,15 @@ type RepoDescriptionProps = {
 
 export default function RepoDescription({ repo }: RepoDescriptionProps) {
   const { data } = useRetrieveReadme(repo);
+  const readmeRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (data && readmeRef.current) {
+      readmeRef.current.querySelectorAll('pre code').forEach((block) => {
+        hljs.highlightElement(block as HTMLElement);
+      });
+    }
+  }, [data]);
 
   return (
     <Section className="h-full overflow-auto">
@@ -49,6 +61,7 @@ export default function RepoDescription({ repo }: RepoDescriptionProps) {
 
       {data && (
         <div
+          ref={readmeRef}
           className="repo-readme font-mono"
           dangerouslySetInnerHTML={{ __html: data }}
         />


### PR DESCRIPTION
## Summary
- highlight plugin README code blocks using highlight.js

## Testing
- `pnpm tests`


------
https://chatgpt.com/codex/tasks/task_e_688024377334832c8fb013402f09169a