### PR TITLE
Increase library test coverage above 85%

### DIFF
--- a/tests/api.test.tsx
+++ b/tests/api.test.tsx
@@ -1,0 +1,86 @@
+import React from "react";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { retrievePlugins, useRetrieveReadme } from "../lib/api";
+import { Repository } from "../lib/definitions";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("api", () => {
+  it("maps plugin data from the API", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        json: async () => ({
+          meta: { total_count: 1 },
+          items: [
+            {
+              full_name: "user/repo",
+              description: "desc",
+              homepage: "",
+              html_url: "",
+              tags: ["tag"],
+              stargazers_count: 3,
+              pretty_forks_count: "1.5k",
+              pushed_at: 123,
+            },
+          ],
+        }),
+      })) as any,
+    );
+
+    const result = await retrievePlugins();
+    expect(globalThis.fetch).toHaveBeenCalled();
+    expect(result.total_repositories).toBe(1);
+    const repo = result.repositories[0];
+    expect(repo.full_name).toBe("user/repo");
+    expect(repo.fork_count).toBe(1500);
+    expect(repo.updated_at).toBe(new Date(123 * 1000).toISOString());
+  });
+
+  it("decodes base64 readme content", async () => {
+    const base64 = Buffer.from("hello world").toString("base64");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        headers: { get: () => "application/json" },
+        json: async () => ({ content: base64, encoding: "base64" }),
+        text: async () => "",
+      })) as any,
+    );
+
+    const repo: Repository = {
+      full_name: "owner/name",
+      description: "",
+      homepage: "",
+      html_url: "",
+      stargazers_count: 0,
+      watchers_count: 0,
+      fork_count: 0,
+      updated_at: "",
+      topics: [],
+    };
+
+    const client = new QueryClient();
+    let query: ReturnType<typeof useRetrieveReadme>;
+
+    const Test = () => {
+      query = useRetrieveReadme(repo);
+      return null;
+    };
+
+    renderToStaticMarkup(
+      <QueryClientProvider client={client}>
+        <Test />
+      </QueryClientProvider>,
+    );
+
+    const result = await query!.refetch();
+    expect(result.data).toBe("hello world");
+  });
+});

--- a/tests/fonts.test.ts
+++ b/tests/fonts.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("next/font/google", () => {
+  return {
+    Inter: vi.fn((opts) => ({ ...opts, className: "inter" })),
+    Lusitana: vi.fn((opts) => ({ ...opts, className: "lusitana" })),
+    Geist: vi.fn((opts) => ({ ...opts })),
+    Geist_Mono: vi.fn((opts) => ({ ...opts })),
+  };
+});
+
+import { inter, lusitana, geistSans, geistMono } from "../lib/fonts";
+import { Inter, Lusitana, Geist, Geist_Mono } from "next/font/google";
+
+describe("fonts", () => {
+  it("initializes google fonts with expected options", () => {
+    expect(Inter).toHaveBeenCalledWith({ subsets: ["latin"] });
+    expect(Lusitana).toHaveBeenCalledWith({
+      weight: ["400", "700"],
+      subsets: ["latin"],
+    });
+    expect(Geist).toHaveBeenCalledWith({
+      variable: "--font-geist-sans",
+      subsets: ["latin"],
+    });
+    expect(Geist_Mono).toHaveBeenCalledWith({
+      variable: "--font-geist-mono",
+      subsets: ["latin"],
+    });
+
+    expect(inter.className).toBe("inter");
+    expect(lusitana.className).toBe("lusitana");
+    expect(geistSans.variable).toBe("--font-geist-sans");
+    expect(geistMono.variable).toBe("--font-geist-mono");
+  });
+});

--- a/tests/store.test.ts
+++ b/tests/store.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const storage: Record<string, string> = {};
+vi.stubGlobal("localStorage", {
+  getItem: (key: string) => (key in storage ? storage[key] : null),
+  setItem: (key: string, value: string) => {
+    storage[key] = value;
+  },
+  removeItem: (key: string) => {
+    delete storage[key];
+  },
+});
+
+const { useStore } = await import("../lib/store");
+
+beforeEach(() => {
+  useStore.setState({
+    filter: "",
+    showFilter: false,
+    theme: "mocha",
+    sort: "default",
+    vimMode: true,
+    showHelp: false,
+    showInstall: false,
+  });
+});
+
+describe("store", () => {
+  it("updates filter and toggles visibility", () => {
+    useStore.getState().setFilter("vim");
+    expect(useStore.getState().filter).toBe("vim");
+    useStore.getState().toggleFilter();
+    expect(useStore.getState().showFilter).toBe(true);
+    useStore.getState().toggleFilter();
+    expect(useStore.getState().showFilter).toBe(false);
+    expect(useStore.getState().filter).toBe("");
+  });
+
+  it("sets theme, sort, vim mode and dialogs", () => {
+    const state = useStore.getState();
+    state.setTheme("latte");
+    state.setSort("stars");
+    state.setVimMode(false);
+    state.setShowHelp(true);
+    state.setShowInstall(true);
+
+    const current = useStore.getState();
+    expect(current.theme).toBe("latte");
+    expect(current.sort).toBe("stars");
+    expect(current.vimMode).toBe(false);
+    expect(current.showHelp).toBe(true);
+    expect(current.showInstall).toBe(true);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,6 +8,8 @@ export default defineConfig({
       provider: "v8",
       reporter: ["text", "json", "html"],
       reportsDirectory: "coverage",
+      include: ["lib/**/*.{ts,tsx}"],
+      exclude: ["lib/definitions.ts"],
     },
   },
   resolve: {


### PR DESCRIPTION
## Summary
- Add tests for API data mapping and README retrieval
- Add tests for font initialization
- Add state management tests for the store and restrict coverage to library modules

## Testing
- `pnpm tests`
- `pnpm coverage`


------
https://chatgpt.com/codex/tasks/task_e_68a71e4c1304832cb23d53b96e30fb93